### PR TITLE
reduce generative testing num-tests, fix pagination tests

### DIFF
--- a/test/ctia/http/generative/atom_store_spec.clj
+++ b/test/ctia/http/generative/atom_store_spec.clj
@@ -13,32 +13,34 @@
                                     helpers/fixture-ctia
                                     helpers/fixture-allow-all-auth]))
 
-(defspec spec-actor-routes-atom-store
+(def num-tests 40)
+
+(defspec spec-actor-routes-atom-store num-tests
   specs/spec-actor-routes)
 
-(defspec spec-campaign-routes-atom-store
+(defspec spec-campaign-routes-atom-store num-tests
   specs/spec-campaign-routes)
 
-(defspec spec-coa-routes-atom-store
+(defspec spec-coa-routes-atom-store num-tests
   specs/spec-coa-routes)
 
-(defspec spec-exploit-target-routes-atom-store
+(defspec spec-exploit-target-routes-atom-store num-tests
   specs/spec-exploit-target-routes)
 
-(defspec spec-feedback-routes-es-store
+(defspec spec-feedback-routes-es-store num-tests
   specs/spec-feedback-routes)
 
-(defspec spec-incident-routes-atom-store
+(defspec spec-incident-routes-atom-store num-tests
   specs/spec-incident-routes)
 
-(defspec spec-indicator-routes-atom-store
+(defspec spec-indicator-routes-atom-store num-tests
   specs/spec-indicator-routes)
 
-(defspec spec-judgement-routes-atom-store
+(defspec spec-judgement-routes-atom-store num-tests
   specs/spec-judgement-routes)
 
-(defspec spec-sighting-routes-atom-store
+(defspec spec-sighting-routes-atom-store num-tests
   specs/spec-ttp-routes)
 
-(defspec spec-ttp-routes-atom-store
+(defspec spec-ttp-routes-atom-store num-tests
   specs/spec-ttp-routes)

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -13,32 +13,34 @@
                                     es-helpers/fixture-recreate-store-indexes
                                     helpers/fixture-allow-all-auth]))
 
-(defspec spec-actor-routes-es-store
+(def num-tests 40)
+
+(defspec spec-actor-routes-es-store num-tests
   specs/spec-actor-routes)
 
-(defspec spec-campaign-routes-es-store
+(defspec spec-campaign-routes-es-store num-tests
   specs/spec-campaign-routes)
 
-(defspec spec-coa-routes-es-store
+(defspec spec-coa-routes-es-store num-tests
   specs/spec-coa-routes)
 
-(defspec spec-exploit-target-routes-es-store
+(defspec spec-exploit-target-routes-es-store num-tests
   specs/spec-exploit-target-routes)
 
-(defspec spec-feedback-routes-es-store
+(defspec spec-feedback-routes-es-store num-tests
   specs/spec-feedback-routes)
 
-(defspec spec-incident-routes-es-store
+(defspec spec-incident-routes-es-store num-tests
   specs/spec-incident-routes)
 
-(defspec spec-indicator-routes-es-store
+(defspec spec-indicator-routes-es-store num-tests
   specs/spec-indicator-routes)
 
-(defspec spec-judgement-routes-es-store
+(defspec spec-judgement-routes-es-store num-tests
   specs/spec-judgement-routes)
 
-(defspec spec-sighting-routes-es-store
+(defspec spec-sighting-routes-es-store num-tests
   specs/spec-ttp-routes)
 
-(defspec spec-ttp-routes-es-store
+(defspec spec-ttp-routes-es-store num-tests
   specs/spec-ttp-routes)

--- a/test/ctia/stores/atom/sighting_test.clj
+++ b/test/ctia/stores/atom/sighting_test.clj
@@ -7,7 +7,7 @@
             [ctim.generators.schemas :as gen]
             [ctim.generators.schemas.sighting-generators :as sg]))
 
-(def num-tests 40)
+(def num-tests 30)
 
 (def gen-observable-and-sightings
   (tcg/let [observable (gen/gen-entity :observable)

--- a/test/ctia/stores/atom/sighting_test.clj
+++ b/test/ctia/stores/atom/sighting_test.clj
@@ -7,6 +7,8 @@
             [ctim.generators.schemas :as gen]
             [ctim.generators.schemas.sighting-generators :as sg]))
 
+(def num-tests 40)
+
 (def gen-observable-and-sightings
   (tcg/let [observable (gen/gen-entity :observable)
             different-observables (tcg/vector
@@ -21,17 +23,17 @@
     [observable
      sightings]))
 
-(defspec spec-handle-list-sightings-by-observables-atom
+(defspec spec-handle-list-sightings-by-observables-atom num-tests
   (for-all [[observable sightings] gen-observable-and-sightings]
-           (let [store (->> sightings
-                            (map (fn [x] [(:id x) x]))
-                            (into {})
-                            atom)]
-             (and
-              ;; Empty search
-              (empty? (:data (sut/handle-list-sightings-by-observables store [] {})))
-              ;; Basic search
-              (= (set (vals @store))
-                 (-> (sut/handle-list-sightings-by-observables store [observable] {})
-                     :data
-                     set))))))
+    (let [store (->> sightings
+                     (map (fn [x] [(:id x) x]))
+                     (into {})
+                     atom)]
+      (and
+       ;; Empty search
+       (empty? (:data (sut/handle-list-sightings-by-observables store [] {})))
+       ;; Basic search
+       (= (set (vals @store))
+          (-> (sut/handle-list-sightings-by-observables store [observable] {})
+              :data
+              set))))))

--- a/test/ctia/test_helpers/pagination.clj
+++ b/test/ctia/test_helpers/pagination.clj
@@ -83,13 +83,15 @@
                        (->> (get route :headers headers)
                             :parsed-body
                             (sort-by field)
-                            (map field))
+                            (map field)
+                            (remove nil?))
                        (->> (get route
                                  :headers headers
                                  :query-params {:sort_by (name field)
                                                 :sort_order "asc"})
                             :parsed-body
-                            (map field)))))
+                            (map field)
+                            (remove nil?)))))
                 sort-fields))))
 
 (defn edge-cases-test [route headers]


### PR DESCRIPTION
Since newer versions of schema, entity generation seem to have increased, the default num-tests makes the test task to hang, this change make the generative tests complete in a reasonable time but keeps the generated entities pretty much complex.